### PR TITLE
Not istorable

### DIFF
--- a/LazyStorage/IConverter.cs
+++ b/LazyStorage/IConverter.cs
@@ -2,7 +2,7 @@
 
 namespace LazyStorage
 {
-    public interface IConverter<T> where T : IEquatable<T>
+    public interface IConverter<T>
     {
         StorableObject GetStorableObject(T item);
         T GetOriginalObject(StorableObject info);

--- a/LazyStorage/IConverter.cs
+++ b/LazyStorage/IConverter.cs
@@ -6,5 +6,6 @@ namespace LazyStorage
     {
         StorableObject GetStorableObject(T item);
         T GetOriginalObject(StorableObject info);
+        bool IsEqual(StorableObject storageObject, T realObject);
     }
 }

--- a/LazyStorage/IConverter.cs
+++ b/LazyStorage/IConverter.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace LazyStorage
+{
+    public interface IConverter<T> where T : IEquatable<T>
+    {
+        StorableObject GetStorableObject(T item);
+        T GetOriginalObject(StorableObject info);
+    }
+}

--- a/LazyStorage/IRepository.cs
+++ b/LazyStorage/IRepository.cs
@@ -5,7 +5,6 @@ namespace LazyStorage
 {
     public interface IRepository<T> : IRepository
     {
-        T GetById(int id);
         ICollection<T> Get(Func<T, bool> exp = null);
         void Upsert(T item);
         void Delete(T item);

--- a/LazyStorage/IStorage.cs
+++ b/LazyStorage/IStorage.cs
@@ -1,8 +1,11 @@
-﻿namespace LazyStorage
+﻿using System;
+
+namespace LazyStorage
 {
     public interface IStorage
     {
         IRepository<T> GetRepository<T>() where T : IStorable<T>, new();
+        IRepository<T> GetRepository<T>(IConverter<T> converter) where T : IEquatable<T>, new();
         void Save();
         void Discard();
     }

--- a/LazyStorage/IStorage.cs
+++ b/LazyStorage/IStorage.cs
@@ -5,7 +5,7 @@ namespace LazyStorage
     public interface IStorage
     {
         IRepository<T> GetRepository<T>() where T : IStorable<T>, new();
-        IRepository<T> GetRepository<T>(IConverter<T> converter) where T : IEquatable<T>, new();
+        IRepository<T> GetRepository<T>(IConverter<T> converter) where T : new();
         void Save();
         void Discard();
     }

--- a/LazyStorage/InMemory/InMemoryRepository.cs
+++ b/LazyStorage/InMemory/InMemoryRepository.cs
@@ -8,11 +8,6 @@ namespace LazyStorage.InMemory
     {
         private readonly List<T> m_Repository = new List<T>();
 
-        public T GetById(int id)
-        {
-            return m_Repository.SingleOrDefault(x => x.Id == id);
-        }
-
         public ICollection<T> Get(Func<T, bool> exp = null)
         {
             return exp != null ? m_Repository.Where(exp).ToList() : m_Repository.ToList();
@@ -38,7 +33,7 @@ namespace LazyStorage.InMemory
 
         public void Delete(T item)
         {
-            var obj = GetById(item.Id);
+            var obj = m_Repository.SingleOrDefault(x => x.Id == item.Id);
             m_Repository.Remove(obj);
         }
 

--- a/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
+++ b/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
@@ -52,8 +52,8 @@ namespace LazyStorage.InMemory
         {
             var storableItem = m_Converter.GetStorableObject(item);
 
-            var obj = m_Repository.SingleOrDefault(x => x.Id == storableItem.Id);
-            m_Repository.Remove(obj);
+            var obj = m_Repository.Where(x => m_Converter.IsEqual(storableItem, item));
+            m_Repository.Remove(obj.First());
         }
 
 

--- a/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
+++ b/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
@@ -14,12 +14,7 @@ namespace LazyStorage.InMemory
         }
 
         private readonly List<StorableObject> m_Repository = new List<StorableObject>();
-
-        public T GetById(int id)
-        {
-            return m_Converter.GetOriginalObject(m_Repository.SingleOrDefault(x => x.Id == id));
-        }
-
+        
         public ICollection<T> Get(Func<T, bool> exp = null)
         {
             var allObjects = m_Repository.Select(item => m_Converter.GetOriginalObject(item)).ToList();

--- a/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
+++ b/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace LazyStorage.InMemory
 {
-    internal class InMemoryRepositoryWithConverter<T> : IRepository<T> where T : IEquatable<T>, new()
+    internal class InMemoryRepositoryWithConverter<T> : IRepository<T> where T : new()
     {
         private readonly IConverter<T> m_Converter;
 
@@ -24,13 +24,13 @@ namespace LazyStorage.InMemory
 
         public void Upsert(T item)
         {
-            var allObjects = m_Repository.Select(i => m_Converter.GetOriginalObject(i)).ToList();
             var storableItem = m_Converter.GetStorableObject(item);
+            var matchingItemsInStore = m_Repository.Where(x => m_Converter.IsEqual(x, item));
 
-            if (allObjects.Contains(item))
+            if (matchingItemsInStore.Any())
             {
                 // Update
-                var obj = m_Repository.Where(x => m_Converter.IsEqual(storableItem, item));
+                var obj = matchingItemsInStore;
                 m_Repository.Remove(obj.First());
                 m_Repository.Add(storableItem);
             }

--- a/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
+++ b/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LazyStorage.InMemory
+{
+    internal class InMemoryRepositoryWithConverter<T> : IRepository<T> where T : IEquatable<T>, new()
+    {
+        private readonly IConverter<T> m_Converter;
+
+        public InMemoryRepositoryWithConverter(IConverter<T> converter)
+        {
+            m_Converter = converter;
+        }
+
+        private readonly List<StorableObject> m_Repository = new List<StorableObject>();
+
+        public T GetById(int id)
+        {
+            return m_Converter.GetOriginalObject(m_Repository.SingleOrDefault(x => x.Id == id));
+        }
+
+        public ICollection<T> Get(Func<T, bool> exp = null)
+        {
+            var allObjects = m_Repository.Select(item => m_Converter.GetOriginalObject(item)).ToList();
+
+            return exp != null ? allObjects.Where(exp).ToList() : allObjects.ToList();
+        }
+
+        public void Upsert(T item)
+        {
+            var storableItem = m_Converter.GetStorableObject(item);
+
+            if (m_Repository.Contains(storableItem))
+            {
+                // Update
+                var obj = m_Repository.Where(x => x.Equals(item));
+                m_Repository.Remove(obj.First());
+                m_Repository.Add(storableItem);
+            }
+            else
+            {
+                // Insert
+                var nextId = m_Repository.Any() ? m_Repository.Max(x => x.Id) + 1 : 1;
+                storableItem.Id = nextId;
+                m_Repository.Add(storableItem);
+            }
+        }
+
+        public void Delete(T item)
+        {
+            var storableItem = m_Converter.GetStorableObject(item);
+
+            var obj = m_Repository.SingleOrDefault(x => x.Id == storableItem.Id);
+            m_Repository.Remove(obj);
+        }
+
+
+        public object Clone()
+        {
+            var newRepo = new InMemoryRepositoryWithConverter<T>(m_Converter);
+
+            foreach (var item in Get())
+            {
+                var info = m_Converter.GetStorableObject(item);
+
+                var temp = m_Converter.GetOriginalObject(info);
+
+                newRepo.Upsert(temp);
+            }
+
+            return newRepo;
+        }
+    }
+}

--- a/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
+++ b/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
@@ -29,12 +29,13 @@ namespace LazyStorage.InMemory
 
         public void Upsert(T item)
         {
+            var allObjects = m_Repository.Select(i => m_Converter.GetOriginalObject(i)).ToList();
             var storableItem = m_Converter.GetStorableObject(item);
 
-            if (m_Repository.Contains(storableItem))
+            if (allObjects.Contains(item))
             {
                 // Update
-                var obj = m_Repository.Where(x => x.Equals(item));
+                var obj = m_Repository.Where(x => m_Converter.IsEqual(storableItem, item));
                 m_Repository.Remove(obj.First());
                 m_Repository.Add(storableItem);
             }

--- a/LazyStorage/InMemory/InMemoryStorage.cs
+++ b/LazyStorage/InMemory/InMemoryStorage.cs
@@ -24,7 +24,7 @@ namespace LazyStorage.InMemory
             return (IRepository<T>) m_Repos[typeAsString];
         }
 
-        public IRepository<T> GetRepository<T>(IConverter<T> converter) where T : IEquatable<T>, new()
+        public IRepository<T> GetRepository<T>(IConverter<T> converter) where T : new()
         {
             var typeAsString = typeof(T).ToString();
 

--- a/LazyStorage/InMemory/InMemoryStorage.cs
+++ b/LazyStorage/InMemory/InMemoryStorage.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace LazyStorage.InMemory
 {
@@ -21,6 +22,18 @@ namespace LazyStorage.InMemory
             }
 
             return (IRepository<T>) m_Repos[typeAsString];
+        }
+
+        public IRepository<T> GetRepository<T>(IConverter<T> converter) where T : IEquatable<T>, new()
+        {
+            var typeAsString = typeof(T).ToString();
+
+            if (!m_Repos.ContainsKey(typeAsString))
+            {
+                m_Repos.Add(typeAsString, new InMemoryRepositoryWithConverter<T>(converter));
+            }
+
+            return (IRepository<T>)m_Repos[typeAsString];
         }
 
         public void Save()

--- a/LazyStorage/LazyStorage.csproj
+++ b/LazyStorage/LazyStorage.csproj
@@ -52,6 +52,7 @@
     <Compile Include="InMemory\InMemoryStorage.cs" />
     <Compile Include="StorableObject.cs" />
     <Compile Include="StorageFactory.cs" />
+    <Compile Include="Xml\XmlRepositoryWithConverter.cs" />
     <Compile Include="Xml\XmlRepository.cs" />
     <Compile Include="Xml\XmlStorage.cs" />
   </ItemGroup>

--- a/LazyStorage/LazyStorage.csproj
+++ b/LazyStorage/LazyStorage.csproj
@@ -50,6 +50,7 @@
     <Compile Include="InMemory\InMemoryRepository.cs" />
     <Compile Include="InMemory\InMemorySingleton.cs" />
     <Compile Include="InMemory\InMemoryStorage.cs" />
+    <Compile Include="StorableObject.cs" />
     <Compile Include="StorageFactory.cs" />
     <Compile Include="Xml\XmlRepository.cs" />
     <Compile Include="Xml\XmlStorage.cs" />

--- a/LazyStorage/LazyStorage.csproj
+++ b/LazyStorage/LazyStorage.csproj
@@ -41,6 +41,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IConverter.cs" />
+    <Compile Include="InMemory\InMemoryRepositoryWithConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="IRepository.cs" />
     <Compile Include="IStorable.cs" />

--- a/LazyStorage/StorableObject.cs
+++ b/LazyStorage/StorableObject.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace LazyStorage
+{
+    public class StorableObject : IEquatable<StorableObject>
+    {
+        public int Id { get; set; }
+        public SerializationInfo Info { get; }
+
+        public StorableObject()
+        {
+            Info = new SerializationInfo(GetType(), new FormatterConverter());
+        }
+        
+        public bool Equals(StorableObject other)
+        {
+            return (other.Id == Id);
+        }
+    }
+}

--- a/LazyStorage/Xml/XmlRepository.cs
+++ b/LazyStorage/Xml/XmlRepository.cs
@@ -15,11 +15,6 @@ namespace LazyStorage.Xml
             XmlFile = file;
         }
 
-        public T GetById(int id)
-        {
-            return Get(x => x.Id == id).SingleOrDefault();
-        }
-
         public ICollection<T> Get(Func<T, bool> exp = null)
         {
             ICollection<T> found = new List<T>();

--- a/LazyStorage/Xml/XmlRepositoryWithConverter.cs
+++ b/LazyStorage/Xml/XmlRepositoryWithConverter.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Xml.Linq;
+
+namespace LazyStorage.Xml
+{
+    internal class XmlRepositoryWithConverter<T> : IRepository<T> where T : new()
+    {
+        private XDocument XmlFile { get; set; }
+        private readonly IConverter<T> m_Converter;
+
+        public XmlRepositoryWithConverter(XDocument file, IConverter<T> converter)
+        {
+            XmlFile = file;
+            m_Converter = converter;
+        }
+
+        public ICollection<T> Get(Func<T, bool> exp = null)
+        {
+            ICollection<T> found = new List<T>();
+
+            foreach (var node in XmlFile.Element("Root").Elements())
+            {
+                var storableObject = new StorableObject();
+
+                foreach (var element in node.Descendants())
+                {
+                    storableObject.Info.AddValue(element.Name.ToString(), element.Value);
+                }
+
+                var temp = m_Converter.GetOriginalObject(storableObject);
+
+                found.Add(temp);
+            }
+
+            var query = found.AsQueryable<T>();
+            return exp != null ? query.Where(exp).ToList() : found;
+        }
+
+        private IEnumerable<StorableObject> GetMatchingItemsInStore(T item)
+        {
+            var found = new List<StorableObject>();
+
+            foreach (var node in XmlFile.Element("Root").Elements())
+            {
+                var storableObject = new StorableObject();
+                var idXElements = node.Descendants("Id");
+                storableObject.Id = int.Parse(idXElements.Single().Value);
+                foreach (var element in node.Descendants())
+                {
+                    storableObject.Info.AddValue(element.Name.ToString(), element.Value);
+                }
+
+                found.Add(storableObject);
+            }
+            return found.Where(x => m_Converter.IsEqual(x, item));
+        }
+
+        public void Upsert(T item)
+        {
+            var storableItem = m_Converter.GetStorableObject(item);
+
+            var matchingItemsInStore = GetMatchingItemsInStore(item);
+
+            if (matchingItemsInStore.Any())
+            {
+                Update(storableItem, matchingItemsInStore.First());
+            }
+            else
+            {
+                Insert(storableItem);
+            }
+        }
+
+        private void Update(StorableObject item, StorableObject oldItem)
+        {
+            var info = item.Info;
+
+            var rootElement = XmlFile.Element("Root");
+            var idXElements = rootElement.Descendants("Id");
+            var node = idXElements.Single(x => x.Value == oldItem.Id.ToString());
+
+            foreach (var data in info)
+            {
+                var asDateTime = (data.Value as DateTime?);
+                if (asDateTime != null)
+                {
+                    node.Parent.Element(data.Name).Value = asDateTime.Value.ToString("s");
+                    continue;
+                }
+
+                node.Parent.Element(data.Name).Value = data.Value.ToString();
+            }
+        }
+
+        private void Insert(StorableObject item)
+        {
+            var typeAsString = typeof (T).ToString();
+
+            var rootElement = XmlFile.Element("Root");
+            var idXElements = rootElement.Descendants("Id");
+
+            item.Id = idXElements.Any() ? idXElements.Max(x => (int) x) + 1 : 1;
+
+            var info = item.Info;
+
+            var newElement = new XElement(typeAsString);
+            newElement.Add(new XElement("Id", item.Id));
+
+            foreach (var data in info)
+            {
+                newElement.Add(new XElement(data.Name, data.Value));
+            }
+
+            rootElement.Add(newElement);
+        }
+
+        public void Delete(T item)
+        {
+            var rootElement = XmlFile.Element("Root");
+            var idXElements = rootElement.Descendants("Id");
+            var node = idXElements.Single(x => x.Value == GetMatchingItemsInStore(item).First().Id.ToString());
+
+            node = node.Parent;
+            node.Remove();
+        }
+
+        public object Clone()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/LazyStorage/Xml/XmlStorage.cs
+++ b/LazyStorage/Xml/XmlStorage.cs
@@ -30,9 +30,16 @@ namespace LazyStorage.Xml
             return m_Repos[typeAsString] as IRepository<T>;
         }
 
-        public IRepository<T> GetRepository<T>(IConverter<T> converter) where T : IEquatable<T>, new()
+        public IRepository<T> GetRepository<T>(IConverter<T> converter) where T : new()
         {
-            throw new NotImplementedException();
+            var typeAsString = typeof(T).ToString();
+
+            if (!m_Repos.ContainsKey(typeAsString))
+            {
+                m_Repos.Add(typeAsString, new XmlRepositoryWithConverter<T>(m_File, converter));
+            }
+
+            return (IRepository<T>)m_Repos[typeAsString];
         }
 
         public void Save()

--- a/LazyStorage/Xml/XmlStorage.cs
+++ b/LazyStorage/Xml/XmlStorage.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Xml.Linq;
 
@@ -27,6 +28,11 @@ namespace LazyStorage.Xml
             }
 
             return m_Repos[typeAsString] as IRepository<T>;
+        }
+
+        public IRepository<T> GetRepository<T>(IConverter<T> converter) where T : IEquatable<T>, new()
+        {
+            throw new NotImplementedException();
         }
 
         public void Save()

--- a/UnitTests/LazyStorageTests.csproj
+++ b/UnitTests/LazyStorageTests.csproj
@@ -64,6 +64,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="RepositoryWithConverterTests.cs" />
     <Compile Include="StorageTypes\InMemoryTestStorage.cs" />
     <Compile Include="StorageTypes\ITestStorage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/UnitTests/LazyStorageTests.csproj
+++ b/UnitTests/LazyStorageTests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="StorageTypes\InMemoryTestStorage.cs" />
     <Compile Include="StorageTypes\ITestStorage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestObjectNotIStorable.cs" />
     <Compile Include="TestObject.cs" />
     <Compile Include="RepositoryTests.cs" />
     <Compile Include="StorageTypes\XmlTestStorage.cs" />

--- a/UnitTests/RepositoryTests.cs
+++ b/UnitTests/RepositoryTests.cs
@@ -54,16 +54,6 @@ namespace LazyStorage.Tests
         }
 
         [Theory, MemberData("Repos")]
-        public void CanGetById(IRepository<TestObject> repo)
-        {
-            var obj = new TestObject();
-
-            repo.Upsert(obj);
-
-            Assert.NotNull(repo.GetById(1));
-        }
-
-        [Theory, MemberData("Repos")]
         public void CanGetByLinq(IRepository<TestObject> repo)
         {
             var objOne = new TestObject {Name = "one"};

--- a/UnitTests/RepositoryWithConverterTests.cs
+++ b/UnitTests/RepositoryWithConverterTests.cs
@@ -11,7 +11,7 @@ namespace LazyStorage.Tests
         public static IEnumerable<object[]> StorageTypes => new[]
         {
             new object[] {new InMemoryTestStorage(), },
-            //new object[] {new XmlTestStorage(), },
+            new object[] {new XmlTestStorage(), },
         };
 
         private ITestStorage m_CurrentStorage;

--- a/UnitTests/RepositoryWithConverterTests.cs
+++ b/UnitTests/RepositoryWithConverterTests.cs
@@ -48,12 +48,12 @@ namespace LazyStorage.Tests
 
             var obj = new TestObjectNotIStorable();
             obj.Name = "Test";
-            obj.StartDate = DateTime.Now;
-            obj.EndDate = DateTime.Now;
+            obj.StartDate = new DateTime(2015, 12, 31, 13, 54, 23);
+            obj.EndDate = new DateTime(2015, 12, 31, 13, 54, 23);
             repo.Upsert(obj);
 
-            obj.StartDate = DateTime.Now;
-            obj.EndDate = DateTime.Now;
+            obj.StartDate = new DateTime(2015, 1, 10, 13, 54, 23);
+            obj.EndDate = new DateTime(2015, 2, 28, 13, 54, 23);
             repo.Upsert(obj);
 
             var repoObj = repo.Get().Single();

--- a/UnitTests/RepositoryWithConverterTests.cs
+++ b/UnitTests/RepositoryWithConverterTests.cs
@@ -60,6 +60,23 @@ namespace LazyStorage.Tests
             Assert.True(repoObj.ContentEquals(obj), "The object returned does not match the one added");
         }
 
+        [Theory, MemberData("StorageTypes")]
+        public void CanDeleteFromRepo(ITestStorage storage)
+        {
+            m_CurrentStorage = storage;
+            var converter = new TestObjectStorageConverter();
+
+            var repo = storage.GetStorage().GetRepository(converter);
+
+            var obj = new TestObjectNotIStorable();
+            obj.Name = "Test";
+
+            repo.Upsert(obj);
+            repo.Delete(obj);
+
+            Assert.False(repo.Get().Any(), "The object could not be deleted from the repository");
+        }
+
         public void Dispose()
         {
             m_CurrentStorage.CleanUp();

--- a/UnitTests/RepositoryWithConverterTests.cs
+++ b/UnitTests/RepositoryWithConverterTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using LazyStorage.Tests.StorageTypes;
+using Xunit;
+
+namespace LazyStorage.Tests
+{
+    public class RepositoryWithConverterTests
+    {
+        public static IEnumerable<object[]> StorageTypes => new[]
+        {
+            new object[] {new InMemoryTestStorage(), },
+        };
+
+        private ITestStorage m_CurrentStorage;
+
+        [Theory, MemberData("StorageTypes")]
+        public void CanAddToRepo(ITestStorage storage)
+        {
+            m_CurrentStorage = storage;
+
+            var converter = new TestObjectStorageConverter();
+
+            var repo = storage.GetStorage().GetRepository(converter);
+
+            var obj = new TestObjectNotIStorable();
+            obj.Name = "Test";
+            obj.StartDate = DateTime.Now;
+            obj.EndDate = DateTime.Now;
+
+            repo.Upsert(obj);
+            
+            var repoObj = repo.Get().Single();
+
+            Assert.True(repoObj.ContentEquals(obj), "The object returned does not match the one added");
+        }
+        
+        public void Dispose()
+        {
+            m_CurrentStorage.CleanUp();
+        }
+    }
+}

--- a/UnitTests/RepositoryWithConverterTests.cs
+++ b/UnitTests/RepositoryWithConverterTests.cs
@@ -11,7 +11,7 @@ namespace LazyStorage.Tests
         public static IEnumerable<object[]> StorageTypes => new[]
         {
             new object[] {new InMemoryTestStorage(), },
-            new object[] {new XmlTestStorage(), },
+            //new object[] {new XmlTestStorage(), },
         };
 
         private ITestStorage m_CurrentStorage;
@@ -94,7 +94,7 @@ namespace LazyStorage.Tests
             var result = repo.Get(x => x.Name == "one").SingleOrDefault();
 
             Assert.NotNull(result);
-            Assert.True(result.Equals(objOne), "The object could not be retrieved from the repository");
+            Assert.True(result.ContentEquals(objOne), "The object could not be retrieved from the repository");
         }
 
         public void Dispose()

--- a/UnitTests/RepositoryWithConverterTests.cs
+++ b/UnitTests/RepositoryWithConverterTests.cs
@@ -35,7 +35,31 @@ namespace LazyStorage.Tests
 
             Assert.True(repoObj.ContentEquals(obj), "The object returned does not match the one added");
         }
-        
+
+        [Theory, MemberData("StorageTypes")]
+        public void CanUpdateRepo(ITestStorage storage)
+        {
+            m_CurrentStorage = storage;
+
+            var converter = new TestObjectStorageConverter();
+
+            var repo = storage.GetStorage().GetRepository(converter);
+
+            var obj = new TestObjectNotIStorable();
+            obj.Name = "Test";
+            obj.StartDate = DateTime.Now;
+            obj.EndDate = DateTime.Now;
+            repo.Upsert(obj);
+
+            obj.StartDate = DateTime.Now;
+            obj.EndDate = DateTime.Now;
+            repo.Upsert(obj);
+
+            var repoObj = repo.Get().Single();
+
+            Assert.True(repoObj.ContentEquals(obj), "The object returned does not match the one added");
+        }
+
         public void Dispose()
         {
             m_CurrentStorage.CleanUp();

--- a/UnitTests/RepositoryWithConverterTests.cs
+++ b/UnitTests/RepositoryWithConverterTests.cs
@@ -77,6 +77,25 @@ namespace LazyStorage.Tests
             Assert.False(repo.Get().Any(), "The object could not be deleted from the repository");
         }
 
+        [Theory, MemberData("StorageTypes")]
+        public void CanGetByLinq(ITestStorage storage)
+        {
+            m_CurrentStorage = storage;
+            var converter = new TestObjectStorageConverter();
+
+            var repo = storage.GetStorage().GetRepository(converter);
+            var objOne = new TestObjectNotIStorable { Name = "one" };
+            var objTwo = new TestObjectNotIStorable { Name = "two" };
+
+            repo.Upsert(objOne);
+            repo.Upsert(objTwo);
+
+            var result = repo.Get(x => x.Name == "one").SingleOrDefault();
+
+            Assert.NotNull(result);
+            Assert.True(result.Equals(objOne), "The object could not be retrieved from the repository");
+        }
+
         public void Dispose()
         {
             m_CurrentStorage.CleanUp();

--- a/UnitTests/RepositoryWithConverterTests.cs
+++ b/UnitTests/RepositoryWithConverterTests.cs
@@ -11,6 +11,7 @@ namespace LazyStorage.Tests
         public static IEnumerable<object[]> StorageTypes => new[]
         {
             new object[] {new InMemoryTestStorage(), },
+            new object[] {new XmlTestStorage(), },
         };
 
         private ITestStorage m_CurrentStorage;

--- a/UnitTests/TestObjectNotIStorable.cs
+++ b/UnitTests/TestObjectNotIStorable.cs
@@ -50,5 +50,10 @@ namespace LazyStorage.Tests
 
             return orginalObject;
         }
+
+        public bool IsEqual(StorableObject storageObject, TestObjectNotIStorable realObject)
+        {
+            return realObject.Name == storageObject.Info.GetString("Name");
+        }
     }
 }

--- a/UnitTests/TestObjectNotIStorable.cs
+++ b/UnitTests/TestObjectNotIStorable.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace LazyStorage.Tests
+{
+    public class TestObjectNotIStorable : IEquatable<TestObjectNotIStorable>
+    {
+        public string Name { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+
+        public TestObjectNotIStorable()
+        {
+            Name = "";
+        }
+
+        public bool Equals(TestObjectNotIStorable other)
+        {
+            return (other.Name == Name);
+        }
+
+        public bool ContentEquals(TestObjectNotIStorable other)
+        {
+            return (other.Name == Name)
+                && (other.StartDate == StartDate)
+                && (other.EndDate == EndDate);
+        }
+    }
+
+    public class TestObjectStorageConverter : IConverter<TestObjectNotIStorable>
+    {
+        public StorableObject GetStorableObject(TestObjectNotIStorable item)
+        {
+            var storableObject = new StorableObject();
+
+            storableObject.Info.AddValue("Name", item.Name);
+            storableObject.Info.AddValue("StartDate", item.StartDate);
+            storableObject.Info.AddValue("EndDate", item.EndDate);
+
+            return storableObject;
+        }
+
+        public TestObjectNotIStorable GetOriginalObject(StorableObject info)
+        {
+            var orginalObject = new TestObjectNotIStorable();
+
+            orginalObject.Name = info.Info.GetString("Name");
+            orginalObject.StartDate = info.Info.GetDateTime("StartDate");
+            orginalObject.EndDate = info.Info.GetDateTime("EndDate");
+
+            return orginalObject;
+        }
+    }
+}

--- a/UnitTests/TestObjectNotIStorable.cs
+++ b/UnitTests/TestObjectNotIStorable.cs
@@ -3,7 +3,7 @@ using System.Runtime.Serialization;
 
 namespace LazyStorage.Tests
 {
-    public class TestObjectNotIStorable : IEquatable<TestObjectNotIStorable>
+    public class TestObjectNotIStorable
     {
         public string Name { get; set; }
         public DateTime StartDate { get; set; }
@@ -12,11 +12,6 @@ namespace LazyStorage.Tests
         public TestObjectNotIStorable()
         {
             Name = "";
-        }
-
-        public bool Equals(TestObjectNotIStorable other)
-        {
-            return (other.Name == Name);
         }
 
         public bool ContentEquals(TestObjectNotIStorable other)


### PR DESCRIPTION
Adds new repositories that don't require the object being stored to be `IStorable` instead the method of serializing the object must be specified in an `IConverter`
