### PR TITLE
Remove the need for items with a converter to be new()

### DIFF
--- a/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
+++ b/LazyStorage/InMemory/InMemoryRepositoryWithConverter.cs
@@ -5,7 +5,7 @@ using LazyStorage.Interfaces;
 
 namespace LazyStorage.InMemory
 {
-    internal class InMemoryRepositoryWithConverter<T> : IRepository<T> where T : new()
+    internal class InMemoryRepositoryWithConverter<T> : IRepository<T>
     {
         private readonly IConverter<T> m_Converter;
 

--- a/LazyStorage/Xml/XmlRepositoryWithConverter.cs
+++ b/LazyStorage/Xml/XmlRepositoryWithConverter.cs
@@ -8,7 +8,7 @@ using LazyStorage.Interfaces;
 
 namespace LazyStorage.Xml
 {
-    internal class XmlRepositoryWithConverter<T> : IRepository<T> where T : new()
+    internal class XmlRepositoryWithConverter<T> : IRepository<T>
     {
         private XDocument XmlFile { get; set; }
         private readonly IConverter<T> m_Converter;


### PR DESCRIPTION
This allows for immutable objects to be stored. Yay!
