### PR TITLE
Make converted objects human readable

### DIFF
--- a/LazyStorage/InMemory/InMemoryStorage.cs
+++ b/LazyStorage/InMemory/InMemoryStorage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using LazyStorage.Interfaces;
 
 namespace LazyStorage.InMemory

--- a/LazyStorage/Interfaces/IStorable.cs
+++ b/LazyStorage/Interfaces/IStorable.cs
@@ -1,12 +1,12 @@
 ﻿using System;
-using System.Runtime.Serialization;
+using System.Collections.Generic;
 
 namespace LazyStorage.Interfaces
 {
     public interface IStorable<T> : IEquatable<T> where T : new()
     {
         int Id { get; set; }
-        SerializationInfo GetStorageInfo();
-        void InitialiseWithStorageInfo(SerializationInfo info);
+        Dictionary<string, string> GetStorageInfo();
+        void InitialiseWithStorageInfo(Dictionary<string, string> info);
     }
 }

--- a/LazyStorage/Json/JsonRepository.cs
+++ b/LazyStorage/Json/JsonRepository.cs
@@ -82,7 +82,7 @@ namespace LazyStorage.Json
 
         public void Save()
         {
-            var fileContent = JsonConvert.SerializeObject(m_Repository);
+            var fileContent = JsonConvert.SerializeObject(m_Repository, Formatting.Indented);
             File.WriteAllText(m_Uri, fileContent);
         }
     }

--- a/LazyStorage/Json/JsonRepositoryWithConverter.cs
+++ b/LazyStorage/Json/JsonRepositoryWithConverter.cs
@@ -88,7 +88,7 @@ namespace LazyStorage.Json
         {
             var convertedItems = m_Repository.Select(item => m_Converter.GetStorableObject(item)).ToList();
 
-            var fileContent = JsonConvert.SerializeObject(convertedItems);
+            var fileContent = JsonConvert.SerializeObject(convertedItems, Formatting.Indented);
             File.WriteAllText(m_Uri, fileContent);
         }
     }

--- a/LazyStorage/Json/JsonRepositoryWithConverter.cs
+++ b/LazyStorage/Json/JsonRepositoryWithConverter.cs
@@ -2,9 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Xml.Linq;
 using LazyStorage.Interfaces;
-using LazyStorage.Xml;
 using Newtonsoft.Json;
 
 namespace LazyStorage.Json

--- a/LazyStorage/Json/JsonStorage.cs
+++ b/LazyStorage/Json/JsonStorage.cs
@@ -1,8 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using LazyStorage.InMemory;
 using LazyStorage.Interfaces;
-using Newtonsoft.Json;
 
 namespace LazyStorage.Json
 {

--- a/LazyStorage/StorableObject.cs
+++ b/LazyStorage/StorableObject.cs
@@ -1,16 +1,16 @@
 using System;
-using System.Runtime.Serialization;
+using System.Collections.Generic;
 
 namespace LazyStorage
 {
     public class StorableObject : IEquatable<StorableObject>
     {
         public int Id { get; set; }
-        public SerializationInfo Info { get; }
+        public Dictionary<string, string> Info { get; }
 
         public StorableObject()
         {
-            Info = new SerializationInfo(GetType(), new FormatterConverter());
+            Info = new Dictionary<string, string>();
         }
         
         public bool Equals(StorableObject other)

--- a/LazyStorage/Xml/XmlRepository.cs
+++ b/LazyStorage/Xml/XmlRepository.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Xml.Linq;
 using LazyStorage.Interfaces;
 
@@ -28,11 +27,11 @@ namespace LazyStorage.Xml
             foreach (var node in m_File.Element("Root").Elements())
             {
                 var temp = new T();
-                var info = new SerializationInfo(temp.GetType(), new FormatterConverter());
+                var info = new Dictionary<string, string>();
                 
                 foreach (var element in node.Descendants())
                 {
-                    info.AddValue(element.Name.ToString(), element.Value);
+                    info.Add(element.Name.ToString(), element.Value);
                 }
 
                 temp.InitialiseWithStorageInfo(info);
@@ -68,14 +67,7 @@ namespace LazyStorage.Xml
 
             foreach (var data in info)
             {
-                var asDateTime = (data.Value as DateTime?);
-                if (asDateTime != null)
-                {
-                    node.Parent.Element(data.Name).Value = asDateTime.Value.ToString("s");
-                    continue;
-                }
-
-                node.Parent.Element(data.Name).Value = data.Value.ToString();
+                node.Parent.Element(data.Key).Value = data.Value;
             }
         }
 
@@ -94,7 +86,7 @@ namespace LazyStorage.Xml
 
             foreach (var data in info)
             {
-                newElement.Add(new XElement(data.Name, data.Value));
+                newElement.Add(new XElement(data.Key, data.Value));
             }
 
             rootElement.Add(newElement);

--- a/LazyStorage/Xml/XmlRepositoryWithConverter.cs
+++ b/LazyStorage/Xml/XmlRepositoryWithConverter.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Xml.Linq;
 using LazyStorage.Interfaces;
 
@@ -34,7 +32,7 @@ namespace LazyStorage.Xml
 
                 foreach (var element in node.Descendants())
                 {
-                    storableObject.Info.AddValue(element.Name.ToString(), element.Value);
+                    storableObject.Info.Add(element.Name.ToString(), element.Value);
                 }
 
                 var temp = m_Converter.GetOriginalObject(storableObject);
@@ -57,7 +55,7 @@ namespace LazyStorage.Xml
                 storableObject.Id = int.Parse(idXElements.Single().Value);
                 foreach (var element in node.Descendants())
                 {
-                    storableObject.Info.AddValue(element.Name.ToString(), element.Value);
+                    storableObject.Info.Add(element.Name.ToString(), element.Value);
                 }
 
                 found.Add(storableObject);
@@ -91,14 +89,7 @@ namespace LazyStorage.Xml
 
             foreach (var data in info)
             {
-                var asDateTime = (data.Value as DateTime?);
-                if (asDateTime != null)
-                {
-                    node.Parent.Element(data.Name).Value = asDateTime.Value.ToString("s");
-                    continue;
-                }
-
-                node.Parent.Element(data.Name).Value = data.Value.ToString();
+                node.Parent.Element(data.Key).Value = data.Value;
             }
         }
 
@@ -118,7 +109,7 @@ namespace LazyStorage.Xml
 
             foreach (var data in info)
             {
-                newElement.Add(new XElement(data.Name, data.Value));
+                newElement.Add(new XElement(data.Key, data.Value));
             }
 
             rootElement.Add(newElement);

--- a/UnitTests/RepositoryTests.cs
+++ b/UnitTests/RepositoryTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Xml.Linq;
 using LazyStorage.InMemory;
 using LazyStorage.Interfaces;
 using LazyStorage.Json;

--- a/UnitTests/StorageTypes/JsonTestStorage.cs
+++ b/UnitTests/StorageTypes/JsonTestStorage.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using LazyStorage.InMemory;
 using LazyStorage.Interfaces;
 
 namespace LazyStorage.Tests.StorageTypes

--- a/UnitTests/TestObject.cs
+++ b/UnitTests/TestObject.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Runtime.Serialization;
+using System.Collections.Generic;
 using LazyStorage.Interfaces;
 
 namespace LazyStorage.Tests
@@ -16,24 +16,24 @@ namespace LazyStorage.Tests
             Name = "";
         }
 
-        public SerializationInfo GetStorageInfo()
+        public Dictionary<string, string> GetStorageInfo()
         {
-            var info = new SerializationInfo(GetType(),new FormatterConverter());
+            var info = new Dictionary<string, string>();
 
-            info.AddValue("Id", Id);
-            info.AddValue("Name", Name);
-            info.AddValue("StartDate", m_StartDate);
-            info.AddValue("EndDate", m_EndDate);
+            info.Add("Id", Id.ToString());
+            info.Add("Name", Name);
+            info.Add("StartDate", m_StartDate.Ticks.ToString());
+            info.Add("EndDate", m_EndDate.Ticks.ToString());
 
             return info;
         }
 
-        public void InitialiseWithStorageInfo(SerializationInfo info)
+        public void InitialiseWithStorageInfo(Dictionary<string, string> info)
         {
-            Id = info.GetInt32("Id");
-            Name = info.GetString("Name");
-            m_StartDate = info.GetDateTime("StartDate");
-            m_EndDate = info.GetDateTime("EndDate");
+            Id = int.Parse(info["Id"]);
+            Name = info["Name"];
+            m_StartDate = new DateTime(long.Parse(info["StartDate"]));
+            m_EndDate = new DateTime(long.Parse(info["EndDate"]));
         }
 
         public bool Equals(TestObject other)

--- a/UnitTests/TestObjectNotIStorable.cs
+++ b/UnitTests/TestObjectNotIStorable.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 using LazyStorage.Interfaces;
 
 namespace LazyStorage.Tests
@@ -29,9 +28,9 @@ namespace LazyStorage.Tests
         {
             var storableObject = new StorableObject();
 
-            storableObject.Info.AddValue("Name", item.Name);
-            storableObject.Info.AddValue("StartDate", item.StartDate);
-            storableObject.Info.AddValue("EndDate", item.EndDate);
+            storableObject.Info.Add("Name", item.Name);
+            storableObject.Info.Add("StartDate", item.StartDate.Ticks.ToString());
+            storableObject.Info.Add("EndDate", item.EndDate.Ticks.ToString());
 
             return storableObject;
         }
@@ -40,16 +39,16 @@ namespace LazyStorage.Tests
         {
             var orginalObject = new TestObjectNotIStorable();
 
-            orginalObject.Name = info.Info.GetString("Name");
-            orginalObject.StartDate = info.Info.GetDateTime("StartDate");
-            orginalObject.EndDate = info.Info.GetDateTime("EndDate");
+            orginalObject.Name = info.Info["Name"];
+            orginalObject.StartDate = new DateTime(long.Parse(info.Info["StartDate"]));
+            orginalObject.EndDate = new DateTime(long.Parse(info.Info["EndDate"]));
 
             return orginalObject;
         }
 
         public bool IsEqual(StorableObject storageObject, TestObjectNotIStorable realObject)
         {
-            return realObject.Name == storageObject.Info.GetString("Name");
+            return realObject.Name == storageObject.Info["Name"];
         }
     }
 }


### PR DESCRIPTION
This is achieved by removing the dependency on `System.Runtime.Serialization`. This has the side effect of letting the library work on .Net Core eventually. The Json serializer works nicely on dictionaries.

This will be a breaking change for any thing using the library and require updating any `IConverter`s or `IStorable` objects.
