### PR TITLE
Enable development in VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+    {
+        "name": ".NET Core Attach",
+        "type": "coreclr",
+        "request": "attach",
+        "processId": "${command:pickProcess}"
+    }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,20 @@
             "label": "test",
             "command": "dotnet test \"src\\LazyStorage.Tests\\LazyStorage.Tests.csproj\"",
             "type": "shell",
-            "group": "test"
+            "group": "test",
+            "problemMatcher": {
+                "owner": "csharptests",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": [
+                {
+                    "regexp": "^\\[(xUnit.net)(.*)\\](.*)(\\[FAIL\\])$",
+                    "file": 1,
+                    "line": 3,
+                    "message": 3,
+                    "loop": true
+                }
+                ]
+            }
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,6 +26,29 @@
                     "message": 4
                 }
             }
+        },
+        {
+            "label": "test (background)",
+            "command": "cd src/LazyStorage.Tests; dotnet watch test \"LazyStorage.Tests.csproj\"",
+            "type": "shell",
+            "group": "test",
+            "problemMatcher": {
+                "owner": "csharptests",
+                "fileLocation": ["absolute"],
+                "pattern": {
+                    "regexp": "^\\[xUnit.net.*\\]\\s*(.*)\\((\\d+),(\\d+)\\):\\sat\\s(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "message": 4
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^.*39mStarted$",
+                    "endsPattern": "^.*Waiting for a file to change before restarting dotnet.*$"
+                }
+            },
+            "isBackground": true
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,16 +17,14 @@
             "group": "test",
             "problemMatcher": {
                 "owner": "csharptests",
-                "fileLocation": ["relative", "${workspaceFolder}"],
-                "pattern": [
-                {
-                    "regexp": "^\\[(xUnit.net)(.*)\\](.*)(\\[FAIL\\])$",
+                "fileLocation": ["absolute"],
+                "pattern": {
+                    "regexp": "^\\[xUnit.net.*\\]\\s*(.*)\\((\\d+),(\\d+)\\):\\sat\\s(.*)$",
                     "file": 1,
-                    "line": 3,
-                    "message": 3,
-                    "loop": true
+                    "line": 2,
+                    "column": 3,
+                    "message": 4
                 }
-                ]
             }
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet build",
+            "type": "shell",
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "test",
+            "command": "dotnet test \"src\\LazyStorage.Tests\\LazyStorage.Tests.csproj\"",
+            "type": "shell",
+            "group": "test"
+        }
+    ]
+}

--- a/build/appveyor.yml
+++ b/build/appveyor.yml
@@ -17,7 +17,7 @@ after_build:
   - appveyor PushArtifact "src\LazyStorage\bin\release\LazyStorage.%GitVersion_NuGetVersion%.nupkg"
 
 test_script:
-  - OpenCover.Console.exe -oldstyle -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:" test ""src\LazyStorage.Tests\LazyStorage.Tests.csproj"" -f netcoreapp2.0" -filter:"+[*]* -[*.Tests*]*" -returntargetcode -output:coverage.xml
+  - OpenCover.Console.exe -oldstyle -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:" test ""src\LazyStorage.Tests\LazyStorage.Tests.csproj"" /p:DebugType=full /p:DebugSymbols=true -f netcoreapp2.0" -filter:"+[*]* -[*.Tests*]*" -returntargetcode -output:coverage.xml
   - codecov -f "coverage.xml"
 
 deploy:

--- a/src/LazyStorage.Tests/LazyStorage.Tests.csproj
+++ b/src/LazyStorage.Tests/LazyStorage.Tests.csproj
@@ -13,10 +13,5 @@
   <ItemGroup>
     <ProjectReference Include="..\LazyStorage\LazyStorage.csproj" />
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
+  
 </Project>

--- a/src/LazyStorage.Tests/LazyStorage.Tests.csproj
+++ b/src/LazyStorage.Tests/LazyStorage.Tests.csproj
@@ -13,5 +13,9 @@
   <ItemGroup>
     <ProjectReference Include="..\LazyStorage\LazyStorage.csproj" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="1.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/LazyStorage/LazyStorage.csproj
+++ b/src/LazyStorage/LazyStorage.csproj
@@ -13,11 +13,6 @@
     <RepositoryUrl>https://github.com/TheEadie/LazyStorage</RepositoryUrl>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>


### PR DESCRIPTION
- Task to build in VS Code
- Task to run test in VS Code
- Setup to debug tests in VS Code
- Moves coverage only compile options to build script. (This works on Windows only)