### PR TITLE
Make test objects sealed

### DIFF
--- a/src/LazyStorage.Tests/PersistenceTests.cs
+++ b/src/LazyStorage.Tests/PersistenceTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace LazyStorage.Tests
 {
-    public class PersistenceTests : IDisposable
+    public sealed class PersistenceTests : IDisposable
     {
         public static IEnumerable<object[]> StorageTypes => new[]
         {

--- a/src/LazyStorage.Tests/TestObject.cs
+++ b/src/LazyStorage.Tests/TestObject.cs
@@ -4,7 +4,7 @@ using LazyStorage.Interfaces;
 
 namespace LazyStorage.Tests
 {
-    public class TestObject : IStorable<TestObject>
+    public sealed class TestObject : IStorable<TestObject>
     {
         public int Id { get; set; }
         public string Name { get; set; }


### PR DESCRIPTION
Two issues as spotted by SonarCloud:
- `IDisposable` should be sealed to prevent inheritors from failing to clean up correctly
- `IComparable` should be sealed to prevent inheritors not overriding and getting incorrect behaviour.

Since these are in the tests they shouldn't matter much.